### PR TITLE
Remove unused dependencies from documentation requirements

### DIFF
--- a/ginipaybusiness/src/doc/requirements.txt
+++ b/ginipaybusiness/src/doc/requirements.txt
@@ -1,7 +1,2 @@
-Jinja2==2.10.1
-MarkupSafe==0.23
-Pygments==2.0.1
-Sphinx==1.2.3
-docutils==0.12
 sphinx-autobuild==0.6.0
 -e git+https://github.com/gini/gini_sphinx_theme_vision.git#egg=gini_sphinx_theme-master


### PR DESCRIPTION
Pygments had to be updated to 2.7.4 but that requires
python 3 and we can't use python 3 because the
`gini-sphinx-theme-vision` requires python 2.