### PR TITLE
Pia 1992 update to gradle7 publish plugin

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,8 +26,8 @@ pipeline {
                     allOf {
                         branch 'main'
                         expression {
-                            def tag = sh(returnStdout: true, script: 'git tag --contains $(git rev-parse HEAD)').trim()
-                            return !tag.isEmpty()
+                            def status = sh(returnStatus: true, script: 'git describe --exact-match HEAD')
+                            return status == 0
                         }
                     }
                 }
@@ -45,8 +45,8 @@ pipeline {
                     allOf {
                         branch 'main'
                         expression {
-                            def tag = sh(returnStdout: true, script: 'git tag --contains $(git rev-parse HEAD)').trim()
-                            return !tag.isEmpty()
+                            def status = sh(returnStatus: true, script: 'git describe --exact-match HEAD')
+                            return status == 0
                         }
                     }
                 }
@@ -70,8 +70,8 @@ pipeline {
                     allOf {
                         branch 'main'
                         expression {
-                            def tag = sh(returnStdout: true, script: 'git tag --contains $(git rev-parse HEAD)').trim()
-                            return !tag.isEmpty()
+                            def status = sh(returnStatus: true, script: 'git describe --exact-match HEAD')
+                            return status == 0
                         }
                     }
                 }
@@ -92,8 +92,8 @@ pipeline {
                     allOf {
                         branch 'main'
                         expression {
-                            def tag = sh(returnStdout: true, script: 'git tag --contains $(git rev-parse HEAD)').trim()
-                            return !tag.isEmpty()
+                            def status = sh(returnStatus: true, script: 'git describe --exact-match HEAD')
+                            return status == 0
                         }
                     }
                 }
@@ -114,8 +114,8 @@ pipeline {
                     allOf {
                         branch 'main'
                         expression {
-                            def tag = sh(returnStdout: true, script: 'git tag --contains $(git rev-parse HEAD)').trim()
-                            return !tag.isEmpty()
+                            def status = sh(returnStatus: true, script: 'git describe --exact-match HEAD')
+                            return status == 0
                         }
                     }
                 }
@@ -134,8 +134,8 @@ pipeline {
                     allOf {
                         branch 'main'
                         expression {
-                            def tag = sh(returnStdout: true, script: 'git tag --contains $(git rev-parse HEAD)').trim()
-                            return !tag.isEmpty()
+                            def status = sh(returnStatus: true, script: 'git describe --exact-match HEAD')
+                            return status == 0
                         }
                     }
                 }
@@ -153,8 +153,8 @@ pipeline {
 //                    allOf {
 //                        branch 'main'
 //                        expression {
-//                            def tag = sh(returnStdout: true, script: 'git tag --contains $(git rev-parse HEAD)').trim()
-//                            return !tag.isEmpty()
+//                            def status = sh(returnStatus: true, script: 'git describe --exact-match HEAD')
+//                            return status == 0
 //                        }
 //                    }
 //                }
@@ -168,8 +168,8 @@ pipeline {
         stage('Release Documentation') {
             when {
                 expression {
-                    def tag = sh(returnStdout: true, script: 'git tag --contains $(git rev-parse HEAD)').trim()
-                    return !tag.isEmpty()
+                    def status = sh(returnStatus: true, script: 'git describe --exact-match HEAD')
+                    return status == 0
                 }
                 expression {
                     boolean publish = false
@@ -206,8 +206,8 @@ pipeline {
         stage('Release Library') {
             when {
                 expression {
-                    def tag = sh(returnStdout: true, script: 'git tag --contains $(git rev-parse HEAD)').trim()
-                    return !tag.isEmpty()
+                    def status = sh(returnStatus: true, script: 'git describe --exact-match HEAD')
+                    return status == 0
                 }
                 expression {
                     boolean publish = false

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,11 +4,6 @@ pipeline {
     environment {
         NEXUS_MAVEN = credentials('external-nexus-maven-repo-credentials')
         GIT = credentials('github')
-//        COMPONENT_API_EXAMPLE_APP_KEYSTORE_PSW = credentials('gini-vision-library-android_component-api-example-app-release-keystore-password')
-//        COMPONENT_API_EXAMPLE_APP_KEY_PSW = credentials('gini-vision-library-android_component-api-example-app-release-key-password')
-//        SCREEN_API_EXAMPLE_APP_KEYSTORE_PSW = credentials('gini-vision-library-android_screen-api-example-app-release-keystore-password')
-//        SCREEN_API_EXAMPLE_APP_KEY_PSW = credentials('gini-vision-library-android_screen-api-example-app-release-key-password')
-//        EXAMPLE_APP_CLIENT_CREDENTIALS = credentials('gini-vision-library-android_gini-api-client-credentials')
         JAVA11 = '/Library/Java/JavaVirtualMachines/temurin-11.jdk/Contents/Home'
     }
     stages {
@@ -144,27 +139,25 @@ pipeline {
                 archiveArtifacts 'ginipaybusiness/build/outputs/aar/*.aar'
             }
         }
-//        stage('Build Example Apps') {
-//            when {
-//                anyOf {
-//                    not {
-//                        branch 'main'
-//                    }
-//                    allOf {
-//                        branch 'main'
-//                        expression {
-//                            def status = sh(returnStatus: true, script: 'git describe --exact-match HEAD')
-//                            return status == 0
-//                        }
-//                    }
-//                }
-//            }
-//            steps {
-//                sh './gradlew screenapiexample::clean screenapiexample::assembleRelease -PreleaseKeystoreFile=screen_api_example.jks -PreleaseKeystorePassword="$SCREEN_API_EXAMPLE_APP_KEYSTORE_PSW" -PreleaseKeyAlias=screen_api_example -PreleaseKeyPassword="$SCREEN_API_EXAMPLE_APP_KEY_PSW" -PclientId=$EXAMPLE_APP_CLIENT_CREDENTIALS_USR -PclientSecret=$EXAMPLE_APP_CLIENT_CREDENTIALS_PSW'
-//                sh './gradlew componentapiexample::clean componentapiexample::assembleRelease -PreleaseKeystoreFile=component_api_example.jks -PreleaseKeystorePassword="$COMPONENT_API_EXAMPLE_APP_KEYSTORE_PSW" -PreleaseKeyAlias=component_api_example -PreleaseKeyPassword="$COMPONENT_API_EXAMPLE_APP_KEY_PSW" -PclientId=$EXAMPLE_APP_CLIENT_CREDENTIALS_USR -PclientSecret=$EXAMPLE_APP_CLIENT_CREDENTIALS_PSW'
-//                archiveArtifacts 'screenapiexample/build/outputs/apk/release/screenapiexample-release.apk,componentapiexample/build/outputs/apk/release/componentapiexample-release.apk,screenapiexample/build/outputs/mapping/release/mapping.txt,componentapiexample/build/outputs/mapping/release/mapping.txt'
-//            }
-//        }
+        stage('Build Example App') {
+            when {
+                anyOf {
+                    not {
+                        branch 'main'
+                    }
+                    allOf {
+                        branch 'main'
+                        expression {
+                            def status = sh(returnStatus: true, script: 'git describe --exact-match HEAD')
+                            return status == 0
+                        }
+                    }
+                }
+            }
+            steps {
+                sh './gradlew app:clean app:assembleDebug -Dorg.gradle.java.home=$JAVA11'
+            }
+        }
         stage('Release Documentation') {
             when {
                 expression {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -195,7 +195,7 @@ pipeline {
             }
             steps {
                 sh '''
-                    ./gradlew ginipaybusiness:uploadArchives \
+                    ./gradlew publishReleasePublicationToSnapshotsRepository \
                     -PmavenSnapshotsRepoUrl=https://repo.gini.net/nexus/content/repositories/snapshots \
                     -PrepoUser=$NEXUS_MAVEN_USR \
                     -PrepoPassword=$NEXUS_MAVEN_PSW
@@ -223,8 +223,8 @@ pipeline {
             }
             steps {
                 sh '''
-                    ./gradlew ginipaybusiness:uploadArchives \
-                    -PmavenRepoUrl=https://repo.gini.net/nexus/content/repositories/open \
+                    ./gradlew publishReleasePublicationToOpenRepository \
+                    -PmavenOpenRepoUrl=https://repo.gini.net/nexus/content/repositories/open \
                     -PrepoUser=$NEXUS_MAVEN_USR \
                     -PrepoPassword=$NEXUS_MAVEN_PSW
                 '''

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,7 +9,7 @@ pipeline {
 //        SCREEN_API_EXAMPLE_APP_KEYSTORE_PSW = credentials('gini-vision-library-android_screen-api-example-app-release-keystore-password')
 //        SCREEN_API_EXAMPLE_APP_KEY_PSW = credentials('gini-vision-library-android_screen-api-example-app-release-key-password')
 //        EXAMPLE_APP_CLIENT_CREDENTIALS = credentials('gini-vision-library-android_gini-api-client-credentials')
-        JAVA9 = '/Users/mobilecd/java-vm/jdk-9.0.4.jdk/Contents/Home'
+        JAVA11 = '/Library/Java/JavaVirtualMachines/temurin-11.jdk/Contents/Home'
     }
     stages {
         stage('Import Pipeline Libraries') {
@@ -33,7 +33,7 @@ pipeline {
                 }
             }
             steps {
-                sh './gradlew clean ginipaybusiness:assembleDebug ginipaybusiness:assembleRelease'
+                sh './gradlew clean ginipaybusiness:assembleDebug ginipaybusiness:assembleRelease -Dorg.gradle.java.home=$JAVA11'
             }
         }
         stage('Unit Tests') {
@@ -52,7 +52,7 @@ pipeline {
                 }
             }
             steps {
-                sh './gradlew ginipaybusiness:testDebugUnitTest -Dorg.gradle.java.home=$JAVA9'
+                sh './gradlew ginipaybusiness:testDebugUnitTest -Dorg.gradle.java.home=$JAVA11'
             }
             post {
                 always {
@@ -77,7 +77,7 @@ pipeline {
                 }
             }
             steps {
-                sh './gradlew ginipaybusiness:lint ginipaybusiness:checkstyle ginipaybusiness:pmd'
+                sh './gradlew ginipaybusiness:lint ginipaybusiness:checkstyle ginipaybusiness:pmd -Dorg.gradle.java.home=$JAVA11'
                 androidLint canComputeNew: false, defaultEncoding: '', healthy: '', pattern: 'ginipaybusiness/build/reports/lint-results.xml', unHealthy: ''
                 checkstyle canComputeNew: false, defaultEncoding: '', healthy: '', pattern: 'ginipaybusiness/build/reports/checkstyle/checkstyle.xml', unHealthy: ''
                 pmd canComputeNew: false, defaultEncoding: '', healthy: '', pattern: 'ginipaybusiness/build/reports/pmd/pmd.xml', unHealthy: ''
@@ -121,7 +121,7 @@ pipeline {
                 }
             }
             steps {
-                sh './gradlew ginipaybusiness:dokkaHtml'
+                sh './gradlew ginipaybusiness:dokkaHtml -Dorg.gradle.java.home=$JAVA11'
                 publishHTML([allowMissing: false, alwaysLinkToLastBuild: false, keepAll: true, reportDir: 'ginipaybusiness/build/dokka/ginipaybusiness', reportFiles: 'index.html', reportName: 'Gini Pay Bank KDoc', reportTitles: ''])
             }
         }
@@ -174,7 +174,7 @@ pipeline {
                 expression {
                     boolean publish = false
                     try {
-                        def version = sh(returnStdout: true, script: './gradlew -q printLibraryVersion').trim()
+                        def version = sh(returnStdout: true, script: './gradlew -q printLibraryVersion -Dorg.gradle.java.home=$JAVA11').trim()
                         def sha = sh(returnStdout: true, script: 'git rev-parse --short HEAD').trim()
                         input "Release documentation for ${version} from branch ${env.BRANCH_NAME} commit ${sha}?"
                         publish = true
@@ -198,7 +198,8 @@ pipeline {
                     ./gradlew publishReleasePublicationToSnapshotsRepository \
                     -PmavenSnapshotsRepoUrl=https://repo.gini.net/nexus/content/repositories/snapshots \
                     -PrepoUser=$NEXUS_MAVEN_USR \
-                    -PrepoPassword=$NEXUS_MAVEN_PSW
+                    -PrepoPassword=$NEXUS_MAVEN_PSW \
+                    -Dorg.gradle.java.home=$JAVA11
                 '''
             }
         }
@@ -211,7 +212,7 @@ pipeline {
                 expression {
                     boolean publish = false
                     try {
-                        def version = sh(returnStdout: true, script: './gradlew -q printLibraryVersion').trim()
+                        def version = sh(returnStdout: true, script: './gradlew -q printLibraryVersion -Dorg.gradle.java.home=$JAVA11').trim()
                         def sha = sh(returnStdout: true, script: 'git rev-parse --short HEAD').trim()
                         input "Release ${version} from branch ${env.BRANCH_NAME} commit ${sha}?"
                         publish = true
@@ -226,7 +227,8 @@ pipeline {
                     ./gradlew publishReleasePublicationToOpenRepository \
                     -PmavenOpenRepoUrl=https://repo.gini.net/nexus/content/repositories/open \
                     -PrepoUser=$NEXUS_MAVEN_USR \
-                    -PrepoPassword=$NEXUS_MAVEN_PSW
+                    -PrepoPassword=$NEXUS_MAVEN_PSW \
+                    -Dorg.gradle.java.home=$JAVA11
                 '''
             }
         }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -38,8 +38,6 @@ dependencies {
 
     implementation project(":ginipaybusiness")
 
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:${versions.kotlin}"
-
     implementation "androidx.core:core-ktx:${versions.core}"
     implementation "androidx.activity:activity-ktx:${versions.activity}"
     implementation "androidx.fragment:fragment-ktx:${versions.fragment}"

--- a/build.gradle
+++ b/build.gradle
@@ -10,8 +10,7 @@ buildscript {
             "coroutines": "1.4.3",
             "androidGradlePlugin": "4.2.2",
 
-            "capture": "1.0.0-beta06",
-            "payapi": "1.0.0-beta04",
+            "payapi": "1.0.0",
 
             "core": "1.3.2",
             "appcompat": "1.2.0",

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
 
             "kotlin": "1.5.21",
             "coroutines": "1.4.3",
-            "androidGradlePlugin": "4.2.2",
+            "androidGradlePlugin": "7.0.0",
 
             "payapi": "1.0.0",
 

--- a/build.gradle
+++ b/build.gradle
@@ -13,13 +13,13 @@ buildscript {
             "payapi": "1.0.0",
 
             "core": "1.3.2",
-            "appcompat": "1.2.0",
-            "activity": "1.2.2",
-            "fragment": "1.3.2",
-            "lifecycle": "2.3.0",
-            "material": "1.3.0",
+            "appcompat": "1.3.1",
+            "activity": "1.3.1",
+            "fragment": "1.3.6",
+            "lifecycle": "2.3.1",
+            "material": "1.4.0",
             "recyclerview": "1.1.0",
-            "constraintlayout": "2.0.4",
+            "constraintlayout": "2.1.0",
 
             "insetter": "0.5.0",
 

--- a/build.gradle
+++ b/build.gradle
@@ -6,9 +6,9 @@ buildscript {
             "minSdk": 19,
             "targetSdk": 30,
 
-            "kotlin": "1.4.31",
+            "kotlin": "1.5.21",
             "coroutines": "1.4.3",
-            "androidGradlePlugin": "4.1.2",
+            "androidGradlePlugin": "4.2.2",
 
             "capture": "1.0.0-beta06",
             "payapi": "1.0.0-beta04",

--- a/ginipaybusiness/build.gradle
+++ b/ginipaybusiness/build.gradle
@@ -46,7 +46,6 @@ android {
 
 dependencies {
 
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:${versions.kotlin}"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:${versions.coroutines}"
 
     api "net.gini:gini-pay-api-lib-android:${versions.payapi}"

--- a/ginipaybusiness/build.gradle
+++ b/ginipaybusiness/build.gradle
@@ -53,8 +53,10 @@ dependencies {
 
     implementation "androidx.lifecycle:lifecycle-common-java8:${versions.lifecycle}"
     implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:${versions.lifecycle}"
+    implementation "androidx.lifecycle:lifecycle-runtime-ktx:${versions.lifecycle}"
     implementation "com.google.android.material:material:${versions.material}"
     implementation "androidx.constraintlayout:constraintlayout:${versions.constraintlayout}"
+    implementation "androidx.fragment:fragment-ktx:${versions.fragment}"
     implementation "androidx.viewpager2:viewpager2:1.0.0"
 
     implementation 'com.github.chrisbanes:PhotoView:2.3.0'

--- a/ginipaybusiness/build.gradle
+++ b/ginipaybusiness/build.gradle
@@ -68,8 +68,8 @@ dependencies {
     testImplementation 'io.mockk:mockk:1.11.0'
     testImplementation 'org.jetbrains.kotlinx:kotlinx-coroutines-test:1.4.3'
     testImplementation 'app.cash.turbine:turbine:0.4.1'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.2'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.3'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
 }
 
 

--- a/ginipaybusiness/build.gradle
+++ b/ginipaybusiness/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'kotlin-android'
     id 'org.jetbrains.dokka'
     id 'kotlin-parcelize'
+    id 'maven-publish'
 }
 
 android {
@@ -71,7 +72,6 @@ dependencies {
 
 
 apply from: rootProject.file('gradle/codequality.gradle')
-apply from: rootProject.file('gradle/maven.gradle')
 apply from: rootProject.file('gradle/multidex_for_tests.gradle')
 
 dokkaHtml {
@@ -109,7 +109,4 @@ task javadocJar(type: Jar, dependsOn: dokkaJavadoc) {
     from dokkaJavadoc.outputDirectory
 }
 
-artifacts {
-    archives sourcesJar
-    archives javadocJar
-}
+apply from: rootProject.file('gradle/maven.gradle')

--- a/ginipaybusiness/src/main/java/net/gini/pay/ginipaybusiness/util/IbanValidator.kt
+++ b/ginipaybusiness/src/main/java/net/gini/pay/ginipaybusiness/util/IbanValidator.kt
@@ -19,7 +19,7 @@ private val countryIbanLength = mapOf(
 private const val alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
 
 internal fun isValidIban(iban: String): Boolean {
-    var ibanNumber = iban.filter { !it.isWhitespace() }.toUpperCase(Locale.US)
+    var ibanNumber = iban.filter { !it.isWhitespace() }.uppercase(Locale.US)
 
     if (countryIbanLength[ibanNumber.take(2)] != ibanNumber.length) return false
 

--- a/gradle/maven.gradle
+++ b/gradle/maven.gradle
@@ -1,71 +1,85 @@
-apply plugin: 'maven'
-
-// In order to upload to the repo, you can create a file ~/.gradle/gradle.properties with
-//
+// Publishing requires the following parameters (you can either pass them in as gradle parameters with -P<paramName>=...
+// or you can add them to a gradle.properties file (for ex. in your global ~/.gradle/gradle.properties file)):
 // repoUser=<your user name>
 // repoPassword=<your password>
-// mavenSnapshotsRepoUrl=<url for snapshots>
-// mavenRepoUrl=<url for releases>
-// mavenLocalRepoUrl=<url for local releases>
-uploadArchives {
-    repositories {
-        mavenDeployer {
-            pom.groupId = groupId
-            pom.artifactId = artifactId
-            pom.version = version
-            if (project.hasProperty('devVersionSuffix')) {
-                pom.version = "${pom.version}.${devVersionSuffix}"
-            }
-            if (project.hasProperty('mavenSnapshotsRepoUrl')) {
-                pom.version = "${pom.version}-SNAPSHOT"
-            }
+//
+// Also at least one of the following parameters are required:
+// mavenOpenRepoUrl=<URL>
+// mavenSnapshotsRepoUrl=<URL>
+// mavenLocalRepoUrl=<URL>
 
-            pom.project {
-                licenses {
-                    license {
-                        name 'Private License'
-                        url 'https://raw.githubusercontent.com/gini/gini-pay-business-sdk-android/master/LICENSE.md'
-                        distribution 'repo'
+// Because the components are created only during the afterEvaluate phase, we must
+// configure our publications using the afterEvaluate() lifecycle method
+afterEvaluate {
+
+    // Create source and javadoc artifacts
+    def sourcesArtifact = artifacts.add('archives', sourcesJar)
+    def javadocArtifact = artifacts.add('archives', javadocJar)
+
+    publishing {
+        publications {
+            // Creates a Maven publication called "release"
+            release(MavenPublication) {
+                // Applies the component for the release build variant
+                from components.release
+
+                // Adds additional artifacts
+                artifact sourcesArtifact
+                artifact javadocArtifact
+
+                // Customizes attributes of the publication
+                groupId = project.groupId
+                artifactId = project.artifactId
+                version = project.version
+
+                if (project.hasProperty('devVersionSuffix')) {
+                    version = "${version}.${devVersionSuffix}"
+                }
+                if (project.hasProperty('mavenSnapshotsRepoUrl')) {
+                    version = "${version}-SNAPSHOT"
+                }
+
+                pom {
+                    licenses {
+                        license {
+                            name = 'Private License'
+                            url = 'https://raw.githubusercontent.com/gini/gini-pay-business-sdk-android/master/LICENSE.md'
+                            distribution = 'repo'
+                        }
+                    }
+                    organization {
+                        name = 'Gini GmbH'
+                        url = 'https://www.gini.net/'
                     }
                 }
-                organization {
-                    name 'Gini GmbH'
-                    url 'https://www.gini.net/'
-                }
             }
+        }
 
-            pom.whenConfigured { pom ->
-                pom.dependencies.forEach { dep ->
-                    if (dep.getArtifactId().startsWith("gini-")) {
-                        dep.setGroupId(groupId)
+        repositories {
+            if (project.hasProperty('mavenOpenRepoUrl')) {
+                maven {
+                    name = "open"
+                    url = mavenOpenRepoUrl
+                    credentials {
+                        username = project.hasProperty('repoUser') ? repoUser : 'invalidUserName'
+                        password = project.hasProperty('repoPassword') ? repoPassword : 'invalidPassword'
                     }
                 }
             }
-
             if (project.hasProperty('mavenSnapshotsRepoUrl')) {
-                repository(url: mavenSnapshotsRepoUrl) {
-                    authentication(
-                            userName: project.hasProperty('repoUser') ? repoUser : "invalidUserName",
-                            password: project.hasProperty('repoPassword') ? repoPassword : "invalidPassword"
-                    )
+                maven {
+                    name = "snapshots"
+                    url = mavenSnapshotsRepoUrl
+                    credentials {
+                        username = project.hasProperty('repoUser') ? repoUser : 'invalidUserName'
+                        password = project.hasProperty('repoPassword') ? repoPassword : 'invalidPassword'
+                    }
                 }
             }
-
-            if (project.hasProperty('mavenRepoUrl')) {
-                repository(url: mavenRepoUrl) {
-                    authentication(
-                            userName: project.hasProperty('repoUser') ? repoUser : 'invalidUserName',
-                            password: project.hasProperty('repoPassword') ? repoPassword : 'invalidPassword'
-                    )
-                }
-            }
-
             if (project.hasProperty('mavenLocalRepoUrl')) {
-                repository(url: mavenLocalRepoUrl) {
-                    authentication(
-                            userName: project.hasProperty('repoUser') ? repoUser : 'invalidUserName',
-                            password: project.hasProperty('repoPassword') ? repoPassword : 'invalidPassword'
-                    )
+                maven {
+                    name = "local"
+                    url = mavenLocalRepoUrl
                 }
             }
         }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.1.1-all.zip


### PR DESCRIPTION
* Migrate to gradle 7 and replace the old maven plugin with the new `maven-publish` plugin for publishing releases to our own maven repository.
* Update the Android Gradle Plugin to the latest version (7.0.0) and use the required Java 11 to run gradle.
* Use Pay Api Lib 1.0.0.
* Update other dependencies.
* Reenable example app builds in Jenkinsfile.

### Ticket 
https://ginis.atlassian.net/browse/PIA-1192
