### PR TITLE
Target sdk version 31 (Android 12) and set `android:exported` attribute

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -12,7 +12,8 @@
         android:supportsRtl="true"
         android:theme="@style/Theme.GiniPayBusiness"
         tools:ignore="AllowBackup">
-        <activity android:name=".MainActivity">
+        <activity android:name=".MainActivity"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/build.gradle
+++ b/build.gradle
@@ -2,9 +2,9 @@
 
 buildscript {
     ext.versions = [
-            "compileSdk": 30,
+            "compileSdk": 31,
             "minSdk": 19,
-            "targetSdk": 30,
+            "targetSdk": 31,
 
             "kotlin": "1.5.21",
             "coroutines": "1.4.3",


### PR DESCRIPTION
When targeting Android 12 activities with intent filters require
the `android:exported` attribute:
https://developer.android.com/about/versions/12/behavior-changes-12#exported