### PR TITLE
Feature/pia 1742 update pay api lib

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ buildscript {
             "coroutines": "1.4.3",
             "androidGradlePlugin": "7.0.0",
 
-            "payapi": "1.0.0",
+            "payapi": "1.0.1",
 
             "core": "1.3.2",
             "appcompat": "1.3.1",

--- a/ginipaybusiness/src/main/java/net/gini/pay/ginipaybusiness/review/ReviewViewModel.kt
+++ b/ginipaybusiness/src/main/java/net/gini/pay/ginipaybusiness/review/ReviewViewModel.kt
@@ -151,6 +151,7 @@ private fun PaymentDetails.overwriteEmptyFields(value: PaymentDetails): PaymentD
     iban = if (iban.trim().isEmpty()) value.iban else iban,
     amount = if (amount.trim().isEmpty()) value.amount else amount,
     purpose = if (purpose.trim().isEmpty()) value.purpose else purpose,
+    extractions = extractions ?: value.extractions,
 )
 
 internal fun getReviewViewModelFactory(giniBusiness: GiniBusiness) = object : ViewModelProvider.Factory {


### PR DESCRIPTION
Update to Gini Pay API Library version 1.0.1.

Fix feedback sending. It wasn't working because extractions were not copied to the `PaymentDetails` of the `ReviewViewModel`.