### PR TITLE
Release version 1.0.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ app/build.gradle:
 
 ```
 dependencies {
-    implementation 'net.gini:gini-pay-business-sdk:1.0.4'
+    implementation 'net.gini:gini-pay-business-sdk:1.0.5'
 }
 ```
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -12,7 +12,8 @@
         android:supportsRtl="true"
         android:theme="@style/Theme.GiniPayBusiness"
         tools:ignore="AllowBackup">
-        <activity android:name=".MainActivity">
+        <activity android:name=".MainActivity"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ buildscript {
             "coroutines": "1.4.3",
             "androidGradlePlugin": "7.0.0",
 
-            "payapi": "1.0.0",
+            "payapi": "1.0.1",
 
             "core": "1.3.2",
             "appcompat": "1.3.1",

--- a/build.gradle
+++ b/build.gradle
@@ -2,9 +2,9 @@
 
 buildscript {
     ext.versions = [
-            "compileSdk": 30,
+            "compileSdk": 31,
             "minSdk": 19,
-            "targetSdk": 30,
+            "targetSdk": 31,
 
             "kotlin": "1.5.21",
             "coroutines": "1.4.3",

--- a/ginipaybusiness/src/doc/source/setup.rst
+++ b/ginipaybusiness/src/doc/source/setup.rst
@@ -22,7 +22,7 @@ app/build.gradle:
 .. code-block:: groovy
 
     dependencies {
-        implementation 'net.gini:gini-pay-business-sdk:1.0.4'
+        implementation 'net.gini:gini-pay-business-sdk:1.0.5'
     }
 
 Gini Pay Deep Link For Your App

--- a/ginipaybusiness/src/main/java/net/gini/pay/ginipaybusiness/review/ReviewViewModel.kt
+++ b/ginipaybusiness/src/main/java/net/gini/pay/ginipaybusiness/review/ReviewViewModel.kt
@@ -151,6 +151,7 @@ private fun PaymentDetails.overwriteEmptyFields(value: PaymentDetails): PaymentD
     iban = if (iban.trim().isEmpty()) value.iban else iban,
     amount = if (amount.trim().isEmpty()) value.amount else amount,
     purpose = if (purpose.trim().isEmpty()) value.purpose else purpose,
+    extractions = extractions ?: value.extractions,
 )
 
 internal fun getReviewViewModelFactory(giniBusiness: GiniBusiness) = object : ViewModelProvider.Factory {

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,4 +21,4 @@ android.enableJetifier=true
 kotlin.code.style=official
 
 groupId=net.gini
-version=1.0.4
+version=1.0.5


### PR DESCRIPTION
* Raises target sdk version to 31 (Android 12).
* Updates the Gini Pay API Library to version [1.0.1](https://github.com/gini/gini-pay-api-lib-android/releases/tag/1.0.1).
* Fixes extraction feedback sending.